### PR TITLE
Use getElementsByTagName to get child nodes

### DIFF
--- a/samples/react-script-editor/src/webparts/scriptEditor/ScriptEditorWebPart.ts
+++ b/samples/react-script-editor/src/webparts/scriptEditor/ScriptEditorWebPart.ts
@@ -196,12 +196,11 @@ export default class ScriptEditorWebPart extends BaseClientSideWebPart<IScriptEd
 
         // main section of function
         const scripts = [];
-        const children_nodes = element.childNodes;
+        const children_nodes = element.getElementsByTagName("script");
 
         for (let i = 0; children_nodes[i]; i++) {
             const child: any = children_nodes[i];
-            if (this.nodeName(child, "script") &&
-                (!child.type || child.type.toLowerCase() === "text/javascript")) {
+            if (!child.type || child.type.toLowerCase() === "text/javascript") {
                 scripts.push(child);
             }
         }


### PR DESCRIPTION

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               | 
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #1325 |

## What's in this Pull Request?

> Use getElementsByTagName to get child nodes, instead of 'childNodes' property to enable retrieval of nodes at any level in element DOM.
Remove check for 'script' tag as not necessary
